### PR TITLE
fix for multiple column rows in strict mode

### DIFF
--- a/packages/core/src/column-resizer.ts
+++ b/packages/core/src/column-resizer.ts
@@ -59,10 +59,7 @@ export class ColumnResizer {
 
   private container: HTMLElement | null = null;
 
-  private barStore = createBarStore({
-    calculateOffset: (current, original) => calculateCoordinateOffset(current, original)[this.axis],
-    getSizeRelatedInfo: () => this.makeSizeInfos(),
-  });
+  private barStore: ReturnType<typeof createBarStore>;
 
   private get axis() {
     return this.config.vertical ? 'y' : 'x';
@@ -80,7 +77,12 @@ export class ColumnResizer {
     return this.eventHub.watchResizerEvent;
   }
 
-  constructor(public readonly config: Readonly<ColumnResizerConfig>) {}
+  constructor(public readonly config: Readonly<ColumnResizerConfig>) {
+    this.barStore = createBarStore({
+      calculateOffset: (current, original) => calculateCoordinateOffset(current, original)[this.axis],
+      getSizeRelatedInfo: () => this.makeSizeInfos(),
+    });
+  }
 
   init(container: HTMLElement | null) {
     this.dispose();


### PR DESCRIPTION
First of all, thanks for a really great UX tool. This fix took a while to figure out, what was happening is that if I have more than one instances of ColumnResizer in our production build, dragging a bar on any of the instances would end up moving the equivalent bar in the last instance on the page.

The fix was to move the class field into the constructor instead. I believe this is because class fields behave differently when "use strict" is added [by webpack, in our build]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#binding_this_with_instance_and_static_methods.